### PR TITLE
Support integration with QuadGK with Measurement objects as endpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ v0.4.0 (201?-??-??)
 
 ### New Features
 
+* `quadgk` function from [`QuadGK.jl`](https://github.com/JuliaMath/QuadGK.jl)
+  package is extended to support `Measurement` objects as endpoints of
+  integration.  Note that only the case of two real endpoints is supported.
 * Real `Measurement` objects can be printed with `"text/x-tex"` and `"text/x-latex"`
   MIME types.  `\pm` TeX macro is used to render the `±` sign.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ it can serve also as an easy-to-use calculator.
   operator.  This makes the code more readable and visually appealing
 * Combined with external packages allows for error propagation of measurements
   with their physical units
+* Support numerical integration
+  with [`QuadGK`](https://github.com/JuliaMath/QuadGK.jl).
 
 Further features are expected to come in the future, see the section "How Can I
 Help?" and the TODO list below.
@@ -140,6 +142,14 @@ measurement(string)
 
 `measurement` function has also a method that enables you to create a
 `Measurement` object from a string.
+
+This module extends many methods defined in Julia’s mathematical standard
+library, and some methods from widespread third-party packages as well.  This is
+the case for most special functions
+in [`SpecialFunctions.jl`](https://github.com/JuliaMath/SpecialFunctions.jl)
+package, and the `quadgk` integration routine
+from [`QuadGK.jl`](https://github.com/JuliaMath/QuadGK.jl) package.  See the
+full manual for details.
 
 ### Caveat about `±` Sign ###
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 Calculus 0.1.5
 SpecialFunctions 0.1.0
+QuadGK 0.1.1

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -480,6 +480,49 @@ measurements.  They work with real and complex measurements, scalars or arrays:
     #     2.9+3.0im
     #     2.8+4.6im
 
+Integrate with ``QuadGK.jl``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The powerful integration routine ``quadgk`` from ``QuadGK.jl`` package is smart
+enough to support out-of-the-box integrand functions that return arbitrary
+types, including ``Measurement``:
+
+.. code-block:: julia
+
+   julia> QuadGK.quadgk(x -> exp(x / (4.73 ± 0.01)), 1, 7)
+   (14.933307243306032 ± 0.009999988180463411, 0.0 ± 0.010017961523508253)
+
+``Measurements.jl`` pushes the capabilities of ``quadgk`` further by supporting
+also ``Measurement`` objects as endpoints:
+
+.. code-block:: julia
+
+   julia> QuadGK.quadgk(cos, 1.19 ± 0.02, 8.37 ± 0.05)
+   (-0.05857827689796702 ± 0.02576650561689427, 2.547162480937004e-11)
+
+Compare this with the expected result:
+
+.. code-block:: julia
+
+   julia> sin(8.37 ± 0.05) - sin(1.19 ± 0.02)
+   -0.058578276897966686 ± 0.02576650561689427
+
+Also with ``quadgk`` correlation is properly taken into account:
+
+.. code-block:: julia
+
+   julia> a = 6.42 ± 0.03
+   6.42 ± 0.03
+
+   julia> QuadGK.quadgk(sin, -a, a)
+   (2.484178227707412e-17 ± 0.0, 0.0)
+
+If instead the two endpoints have, by chance, the same nominal value and
+uncertainty but are not correlated:
+
+   julia> QuadGK.quadgk(sin, -6.42 ± 0.03, 6.42 ± 0.03)
+   (2.484178227707412e-17 ± 0.005786464233000303, 0.0)
+
 Use with ``SIUnits.jl`` and ``Unitful.jl``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -44,6 +44,13 @@ expressions of functions’ derivatives.
 In addition, it is possible to create a ``Complex`` measurement with
 ``complex(measurement(a, b), measurement(c, d))``.
 
+This module extends many methods defined in Julia’s mathematical standard
+library, and some methods from widespread third-party packages as well.  This is
+the case for most special functions in `SpecialFunctions.jl
+<https://github.com/JuliaMath/SpecialFunctions.jl>`__ package, and the
+``quadgk`` integration routine from `QuadGK.jl
+<https://github.com/JuliaMath/QuadGK.jl>`__ package.
+
 Those interested in the technical details of the package, in order integrate the
 package in their workflow, can have a look at the technical appendix.
 

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -21,8 +21,8 @@ __precompile__()
 
 module Measurements
 
-# This is used to calculate numerical derivatives in "@uncertain" macro.
-using Calculus, SpecialFunctions
+# Calculus is used to calculate numerical derivatives in "@uncertain" macro.
+using Calculus
 
 # Function to handle new type
 import Base: alignment, show

--- a/src/math.jl
+++ b/src/math.jl
@@ -25,6 +25,9 @@
 #
 ### Code:
 
+# Here we use and extend some methods defined in the following modules.
+using SpecialFunctions, QuadGK
+
 export @uncertain
 
 # This function is to be used by methods of mathematical operations to produce a
@@ -938,4 +941,47 @@ function prod{T<:Measurement}(a::AbstractArray{T})
     return result(prod(x),
                   [prod(deleteat!(copy(x), i)) for i in eachindex(x)],
                   a)
+end
+
+### Integration with QuadGK
+
+# Helper functions to handle result of integration with QuadGK when endpoints are
+# Measurement objects.
+
+# The integral itself is a Measurement object, propagate its uncertainty.
+quadgk_result(integral::Measurement, derivative::Real, a::Measurement) =
+    result(integral.val, (1, derivative.val), (integral, a))
+quadgk_result(integral::Measurement, derivatives::Tuple, a::Tuple) =
+    result(integral.val, (1, value.(derivatives)...), (integral, a...))
+# Only endpoints are are Measurement objects.
+quadgk_result(integral::Real, derivative::Real, a::Measurement) =
+    result(integral, derivative, a)
+quadgk_result(integral::Real, derivatives::Tuple, a::Tuple) =
+    result(integral, derivatives, a)
+
+# Upper bound is a Measurement.  The derivative is f(b).
+function QuadGK.quadgk{T<:AbstractFloat}(f, a, b::Measurement{T}; kws...)
+    F = promote_type(typeof(float(a)), T)
+    bval = b.val
+    integral = QuadGK.quadgk(f, convert(F, a), convert(F, bval); kws...)
+    return (quadgk_result(integral[1], f(bval), b), integral[2])
+end
+
+# Lower bound is a Measurement.  The derivative is -f(a).
+function QuadGK.quadgk{T<:AbstractFloat}(f, a::Measurement{T}, b; kws...)
+    F = promote_type(typeof(float(b)), T)
+    aval = a.val
+    integral = QuadGK.quadgk(f, convert(F, aval), convert(F, b); kws...)
+    return (quadgk_result(integral[1], -f(aval), a), integral[2])
+end
+
+# Both bounds are Measurement's.  Derivatives are -f(a) and f(b).
+function QuadGK.quadgk{T<:AbstractFloat,S<:AbstractFloat}(f, a::Measurement{T},
+                                                          b::Measurement{S};
+                                                          kws...)
+    F = promote_type(T, S)
+    aval = a.val
+    bval = b.val
+    integral = QuadGK.quadgk(f, convert(F, aval), convert(F, bval); kws...)
+    return (quadgk_result(integral[1], (-f(aval), f(bval)), (a, b)), integral[2])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -482,6 +482,7 @@ for X in (a, b, c); @test sin(X*X + X*X)/cos(X*X + X*X) ≈ tan(2X^2); end
 
 @testset "QuadGK" begin
     @test QuadGK.quadgk(cos, x, y)[1] ≈ sin(y) - sin(x)
+    @test QuadGK.quadgk(sin, -y, y)[1] ≈ cos(-y) - cos(y) atol = eps(Float64)
     @test QuadGK.quadgk(exp, 0.4, x)[1] ≈ exp(x) - exp(0.4)
     @test QuadGK.quadgk(sin, w, 2.7)[1] ≈ cos(w) - cos(2.7)
     @test QuadGK.quadgk(x -> cos(x - w), -w, w)[1] ≈ sin(2w)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -480,6 +480,17 @@ for X in (a, b, c); @test sin(X*X + X*X)/cos(X*X + X*X) ≈ tan(2X^2); end
     big"8.750000036458332770409319189914605364095140370607375793457032012939451217651416e-01" ±
     big"3.416666677095189699499391052146002403356891669706809079678073000173723744722607e-02"
 
+@testset "QuadGK" begin
+    @test QuadGK.quadgk(cos, x, y)[1] ≈ sin(y) - sin(x)
+    @test QuadGK.quadgk(exp, 0.4, x)[1] ≈ exp(x) - exp(0.4)
+    @test QuadGK.quadgk(sin, w, 2.7)[1] ≈ cos(w) - cos(2.7)
+    @test QuadGK.quadgk(x -> cos(x - w), -w, w)[1] ≈ sin(2w)
+    @test QuadGK.quadgk(t -> exp(t / x), w, y)[1] ≈ x * (exp(y / x) - exp(w / x))
+    @test QuadGK.quadgk(t -> sin(t - w), 0, y)[1] ≈ cos(w) - cos(y - w)
+    @test QuadGK.quadgk(t -> log(y - t), w, -pi)[1] ≈
+        (y - w)*log(y - w) - (y + pi)*log(y + pi) + w + pi
+end
+
 ##### Parsing of strings
 @test measurement("  -123.4(56)  ") ≈         -123.4 ± 5.6
 @test measurement("  +1234(56)e-1  ") ≈        123.4 ± 5.6


### PR DESCRIPTION
`QuadGK` supports out-of-the-box integration with integrand functions that return arbitrary types, including `Measurement`.  This pull requests further extends the `quadgk` method by supporting `Measurement` objects as endpoints of the integral.

As side effect, this fixes issue JuliaAstro/Cosmology.jl#7